### PR TITLE
feat(astro2): Fix base root when set with astro build --base flag/option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ type EnableManifestTransform = () => {
   trailingSlash: 'never' | 'always' | 'ignore'
 }
 
-function createManifestTransform(enableManifestTransform: EnableManifestTransform): ManifestTransform {
+function createManifestTransform(enableManifestTransform: EnableManifestTransform, config: AstroConfig): ManifestTransform {
   return async (entries) => {
     const { doBuild, trailingSlash } = enableManifestTransform()
     if (!doBuild)
@@ -41,10 +41,10 @@ function createManifestTransform(enableManifestTransform: EnableManifestTransfor
 
     entries.filter(e => e && e.url.endsWith('.html')).forEach((e) => {
       if (e.url === 'index.html') {
-        e.url = '/'
+        e.url = config.base ?? config.vite?.base ?? '/'
       }
       else if (e.url === '404.html') {
-        e.url = '/404'
+        e.url = '404'
       }
       else {
         const url = e.url.slice(0, e.url.lastIndexOf('/'))
@@ -93,7 +93,7 @@ function getViteConfiguration(
     newOptions.workbox = useWorkbox
 
     newOptions.workbox.manifestTransforms = newOptions.workbox.manifestTransforms ?? []
-    newOptions.workbox.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+    newOptions.workbox.manifestTransforms.push(createManifestTransform(enableManifestTransform, config))
 
     return {
       plugins: [VitePWA(newOptions)],
@@ -102,7 +102,7 @@ function getViteConfiguration(
 
   options.injectManifest = options.injectManifest ?? {}
   options.injectManifest.manifestTransforms = injectManifest.manifestTransforms ?? []
-  options.injectManifest.manifestTransforms.push(createManifestTransform(enableManifestTransform))
+  options.injectManifest.manifestTransforms.push(createManifestTransform(enableManifestTransform, config))
 
   return {
     plugins: [VitePWA(options)],


### PR DESCRIPTION
Hi @userquin,

Astro 2 has the configuration options [site](https://docs.astro.build/en/reference/configuration-reference/#site) and [base](https://docs.astro.build/en/reference/configuration-reference/#base) and can be set with the CLI flags [--site](https://docs.astro.build/en/reference/cli-reference/#--site) and [--base](https://docs.astro.build/en/reference/cli-reference/#--base). The values set  by CLI flags overrides the ones set in `astro.config.mjs`.

Setting `site` and `base` you can deploy a GitHub Page like `https://<username>.github.io/<repo>`, but when build an Astro site with `pnpm build --site http://localhost:3000 --base /astro-paper` the generated sw.js has wrong `index` and `404` url:

![vite-pwa-astro-01](https://user-images.githubusercontent.com/9409275/219771832-123a264f-76b6-4bbd-975c-1ee00e04d9bc.png)

With the changes suggested as workaround in the function [createManifestTransform](https://github.com/carlesbarreda/vite-pwa-astro/blob/ec58bfe34f07849b830d1d6083577bcaead40e87/src/index.ts#L36) generates the expected urls in sw.js:

![vite-pwa-astro-02](https://user-images.githubusercontent.com/9409275/219781275-ccd91f0a-8c03-4626-8ff6-acde76a76e25.png)

Another issue is the imported `pwaInfo` from `virtual:pwa-info` in the main layout, like in the [example](https://vite-pwa-org.netlify.app/frameworks/astro.html#prompt-for-update), is `undefined` and must set manually the manifest link in the html header. Maybe can be possible, when solve this issue, to generate the headers for [document base](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) and [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) in `pwaInfo.webManifest.linkTag` when appropiated, something like this:

```html
    <link rel="manifest" href="/base/manifest.webmanifest" />
    <base href="/base/" />
```

Astro docs reference for [base](https://docs.astro.build/en/reference/configuration-reference/#base) says _You can access this value via `import.meta.env.BASE_URL`_. Astro 2 build process seems be done in two steps. First step `import.meta.env` seem is filled with wrong values:

![vite-pwa-astro-03](https://user-images.githubusercontent.com/9409275/219796081-a95f05a8-0b9d-4ac8-8b60-384fcef05c4a.png)

Second step, when generating the static routes, `import.meta.env` looks correct:

![vite-pwa-astro-04](https://user-images.githubusercontent.com/9409275/219798749-c6556c13-81b5-4445-bf82-3d39831f59be.png)

Maybe `pwaInfo` issue and `import.meta.env` behaivor are related.

I forked the [AstroPaper](https://github.com/satnaing/astro-paper) blog theme and added my fork of @vite-pwa/astro plugin in my [astropaper-pwa](https://github.com/carlesbarreda/astro-paper/tree/astropaper-pwa) branch, but get this [error](https://github.com/carlesbarreda/astro-paper/actions/runs/4210765253/jobs/7308662312#step:5:142) when try to deploy, maybe is related to this [pnpm issue](https://github.com/pnpm/pnpm/issues/6005). But works locally.
