### PR TITLE
Fixing peer dep semver with up to date vite-plugin-pwa

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
   },
   "peerDependencies": {
     "astro": "^1.6.0 || ^2.0.0",
-    "vite-plugin-pwa": "^0.14.0"
+    "vite-plugin-pwa": ">=0.14.0 <1"
   },
   "dependencies": {
-    "vite-plugin-pwa": "^0.14.4"
+    "vite-plugin-pwa": ">=0.14.4 <1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.35.3",


### PR DESCRIPTION
It seems to work well with `vite-plugin-pwa` 0.15 and 0.16, but current semantic verion stills requiring peer 0.14.x.