### PR TITLE
fix: handle directory and trailing slashes properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ this plugin.
 
 ## ⚡️ Examples
 
-| Example                 | Source                                                                                      | Playground                                                                                     |
-|-------------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| Example                 | Source                                                                                     | Playground                                                                                     |
+|-------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `Auto Update PWA`       | [GitHub](https://github.com/vite-pwa/astro/tree/main/examples/pwa-simple)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-simple) |
-| `Prompt for Update PWA` | [GitHub](https://github.com/unplugin/unplugin-icons/tree/main/examples/pwa-prompt)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-prompt) |
+| `Prompt for Update PWA` | [GitHub](https://github.com/vite-pwa/astro/tree/main/examples/pwa-prompt)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-prompt) |
 
 
 ## 👀 Full config

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ this plugin.
 | Example                 | Source                                                                                      | Playground                                                                                     |
 |-------------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `Auto Update PWA`       | [GitHub](https://github.com/vite-pwa/astro/tree/main/examples/pwa-simple)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-simple) |
-| `Prompt for Update PWA` | [GitHub](https://github.com/unplugin/unplugin-icons/tree/main/examples/prompt)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-prompt) |
+| `Prompt for Update PWA` | [GitHub](https://github.com/unplugin/unplugin-icons/tree/main/examples/pwa-prompt)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-prompt) |
 
 
 ## 👀 Full config

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ export default defineConfig({
 Read the [📖 documentation](https://vite-pwa-org.netlify.app/frameworks/astro) for a complete guide on how to configure and use
 this plugin.
 
+## ⚡️ Examples
+
+| Example                 | Source                                                                                      | Playground                                                                                     |
+|-------------------------|---------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `Auto Update PWA`       | [GitHub](https://github.com/vite-pwa/astro/tree/main/examples/pwa-simple)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-simple) |
+| `Prompt for Update PWA` | [GitHub](https://github.com/unplugin/unplugin-icons/tree/main/examples/prompt)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-prompt) |
+
+
 ## 👀 Full config
 
 Check out the following links for more details:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ this plugin.
 
 ## ⚡️ Examples
 
+You need to stop the dev server once started and then run `npm run build && npm run preview` to see the PWA in action.
+
 | Example                 | Source                                                                                     | Playground                                                                                     |
 |-------------------------|--------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | `Auto Update PWA`       | [GitHub](https://github.com/vite-pwa/astro/tree/main/examples/pwa-simple)               | [Play Online](https://stackblitz.com/fork/github/vite-pwa/astro/tree/main/examples/pwa-simple) |

--- a/examples/pwa-prompt/.stackblitz.js
+++ b/examples/pwa-prompt/.stackblitz.js
@@ -1,0 +1,15 @@
+import { promises as fsPromises } from 'node:fs'
+
+updatePackageJson()
+
+async function updatePackageJson() {
+    const filename = './package.json'
+    try {
+        const contents = await fsPromises.readFile(filename, 'utf-8')
+        const updatedContent = contents.replace('workspace:*', 'latest')
+        await fsPromises.writeFile(filename, updatedContent)
+    }
+    catch (err) {
+        console.error(err)
+    }
+}

--- a/examples/pwa-prompt/package.json
+++ b/examples/pwa-prompt/package.json
@@ -14,5 +14,9 @@
     "@vite-pwa/astro": "workspace:*",
     "astro": "^3.0.5",
     "workbox-window": "^7.0.0"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "node .stackblitz.js && npm install && npm run dev"
   }
 }

--- a/examples/pwa-simple/.stackblitz.js
+++ b/examples/pwa-simple/.stackblitz.js
@@ -1,0 +1,15 @@
+import { promises as fsPromises } from 'node:fs'
+
+updatePackageJson()
+
+async function updatePackageJson() {
+    const filename = './package.json'
+    try {
+        const contents = await fsPromises.readFile(filename, 'utf-8')
+        const updatedContent = contents.replace('workspace:*', 'latest')
+        await fsPromises.writeFile(filename, updatedContent)
+    }
+    catch (err) {
+        console.error(err)
+    }
+}

--- a/examples/pwa-simple/astro.config.mjs
+++ b/examples/pwa-simple/astro.config.mjs
@@ -42,6 +42,10 @@ export default defineConfig({
       workbox: {
         navigateFallback: '/404',
         globPatterns: ['**/*.{css,js,html,svg,png,ico,txt}'],
+        /*manifestTransforms: [async (manifestEntries) => {
+          console.log('manifestEntries', manifestEntries)
+          return { manifest: manifestEntries, warnings: [] }
+        }],*/
       },
       devOptions: {
         enabled: true,

--- a/examples/pwa-simple/package.json
+++ b/examples/pwa-simple/package.json
@@ -14,5 +14,9 @@
     "@vite-pwa/astro": "workspace:*",
     "astro": "^3.0.5",
     "workbox-window": "^7.0.0"
+  },
+  "stackblitz": {
+    "installDependencies": false,
+    "startCommand": "node .stackblitz.js && npm install && npm run dev"
   }
 }

--- a/examples/pwa-simple/src/pages/index.astro
+++ b/examples/pwa-simple/src/pages/index.astro
@@ -4,4 +4,8 @@ import DefaultLayout from '../layouts/DefaultLayout.astro';
 <DefaultLayout title="Astro PWA">
     <h1>Welcome to <a href="https://astro.build/">Astro</a> PWA</h1>
     <a href="/about">Go About</a>
+    <br/>
+    <a href="/test">Go to /test</a>
+    <br/>
+    <a href="/test/">Go to /test/</a>
 </DefaultLayout>

--- a/examples/pwa-simple/src/pages/test/about.astro
+++ b/examples/pwa-simple/src/pages/test/about.astro
@@ -1,0 +1,9 @@
+---
+import DefaultLayout from '../../layouts/DefaultLayout.astro';
+---
+<DefaultLayout title="About Test Astro PWA">
+    <h1>Welcome to <a href="https://astro.build/">Astro</a> PWA</h1>
+    <a href="/test">Go /test</a>
+    <br/>
+    <a href="/test/">Go /test/</a>
+</DefaultLayout>

--- a/examples/pwa-simple/src/pages/test/index.astro
+++ b/examples/pwa-simple/src/pages/test/index.astro
@@ -6,4 +6,6 @@ import DefaultLayout from '../../layouts/DefaultLayout.astro';
     <a href="/test/about">Go to /test/about</a>
     <br/>
     <a href="/test/about/">Go to /test/about/</a>
+    <br/>
+    <a href="/">Go to /</a>
 </DefaultLayout>

--- a/examples/pwa-simple/src/pages/test/index.astro
+++ b/examples/pwa-simple/src/pages/test/index.astro
@@ -1,0 +1,9 @@
+---
+import DefaultLayout from '../../layouts/DefaultLayout.astro';
+---
+<DefaultLayout title="Test Astro PWA">
+    <h1>Welcome to <a href="https://astro.build/">Astro</a> PWA</h1>
+    <a href="/test/about">Go to /test/about</a>
+    <br/>
+    <a href="/test/about/">Go to /test/about/</a>
+</DefaultLayout>

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.41.0",
     "@antfu/ni": "^0.21.8",
-    "@types/node": "^20.8.7",
     "@types/debug": "^4.1.8",
+    "@types/node": "^20.8.7",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "astro": "^3.0.5",
     "bumpp": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.41.0",
     "@antfu/ni": "^0.21.8",
+    "@types/node": "^20.8.7",
     "@types/debug": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "astro": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/astro",
   "type": "module",
   "version": "0.1.3",
-  "packageManager": "pnpm@8.7.4",
+  "packageManager": "pnpm@8.9.2",
   "description": "Zero-config PWA for Astro",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,12 +21,15 @@ importers:
       '@types/debug':
         specifier: ^4.1.8
         version: 4.1.8
+      '@types/node':
+        specifier: ^20.8.7
+        version: 20.8.7
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.6.0
         version: 6.6.0(@typescript-eslint/parser@6.5.0)(eslint@8.49.0)(typescript@5.2.2)
       astro:
         specifier: ^3.0.5
-        version: 3.0.5
+        version: 3.0.5(@types/node@20.8.7)
       bumpp:
         specifier: ^9.2.0
         version: 9.2.0
@@ -44,7 +47,7 @@ importers:
         version: 1.2.1
       vite:
         specifier: ^4.3.9
-        version: 4.3.9
+        version: 4.3.9(@types/node@20.8.7)
 
   examples/pwa-prompt:
     dependencies:
@@ -53,7 +56,7 @@ importers:
         version: link:../..
       astro:
         specifier: ^3.0.5
-        version: 3.0.5
+        version: 3.0.5(@types/node@20.8.7)
       workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
@@ -65,7 +68,7 @@ importers:
         version: link:../..
       astro:
         specifier: ^3.0.5
-        version: 3.0.5
+        version: 3.0.5(@types/node@20.8.7)
       workbox-window:
         specifier: ^7.0.0
         version: 7.0.0
@@ -209,7 +212,7 @@ packages:
       astro: ^3.0.0
     dependencies:
       '@astrojs/prism': 3.0.0
-      astro: 3.0.5
+      astro: 3.0.5(@types/node@20.8.7)
       github-slugger: 2.0.0
       import-meta-resolve: 3.0.0
       rehype-raw: 6.1.1
@@ -308,7 +311,7 @@ packages:
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2408,9 +2411,10 @@ packages:
     dependencies:
       '@types/unist': 2.0.6
 
-  /@types/node@18.7.18:
-    resolution: {integrity: sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==}
-    dev: false
+  /@types/node@20.8.7:
+    resolution: {integrity: sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==}
+    dependencies:
+      undici-types: 5.25.3
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2422,7 +2426,7 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.7.18
+      '@types/node': 20.8.7
     dev: false
 
   /@types/resolve@1.20.2:
@@ -2818,7 +2822,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /astro@3.0.5:
+  /astro@3.0.5(@types/node@20.8.7):
     resolution: {integrity: sha512-g6WOl39HyzQJhPSkcO+Tvm3aZ2ZumfAPnxyhnFKmFRDOI78a59iW9EdRl9TbLH6Cinj2CQiOBATfGiR2FU4EXg==}
     engines: {node: '>=18.14.1', npm: '>=6.14.0'}
     hasBin: true
@@ -2874,7 +2878,7 @@ packages:
       undici: 5.23.0
       unist-util-visit: 4.1.2
       vfile: 5.3.7
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.8.7)
       vitefu: 0.2.4(vite@4.4.9)
       which-pm: 2.0.0
       yargs-parser: 21.1.1
@@ -5095,7 +5099,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.7.18
+      '@types/node': 20.8.7
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -6669,11 +6673,6 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
-    dev: true
-
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -7328,6 +7327,9 @@ packages:
       - supports-color
     dev: true
 
+  /undici-types@5.25.3:
+    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+
   /undici@5.23.0:
     resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
     engines: {node: '>=14.0'}
@@ -7542,14 +7544,14 @@ packages:
       debug: 4.3.4
       fast-glob: 3.3.1
       pretty-bytes: 6.1.1
-      vite: 4.3.9
+      vite: 4.3.9(@types/node@20.8.7)
       workbox-build: 7.0.0
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /vite@4.3.9:
+  /vite@4.3.9(@types/node@20.8.7):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -7574,13 +7576,14 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.8.7
       esbuild: 0.17.19
       postcss: 8.4.24
       rollup: 3.24.0
     optionalDependencies:
       fsevents: 2.3.2
 
-  /vite@4.4.9:
+  /vite@4.4.9(@types/node@20.8.7):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -7608,6 +7611,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.8.7
       esbuild: 0.18.20
       postcss: 8.4.29
       rollup: 3.28.1
@@ -7622,7 +7626,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.4.9
+      vite: 4.4.9(@types/node@20.8.7)
 
   /vscode-oniguruma@1.7.0:
     resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}


### PR DESCRIPTION
This PR also includes:
- add logical manifest entries instead replacing original ones
- don't add manifestTransform when provided
- included `test` folder in `pwa-simple` example, with `index.astro` and `about.astro` routes: `/test`, `/test/`, `/test/about` and `/test/about/` working
- map `404.astro` to `404`, Astro won't generate the `404/index.html` and the sw will fail when precaching `404.html` page
- include StackBlitz links to run the examples: added to readme and included hints to run the PWA
- bump to pnpm `8.9.2`

You can open the pwa-example using [this StackBlitz repro](https://stackblitz.com/fork/github/vite-pwa/astro/tree/userquin/fix-allow-custom-manifest-transform/examples/pwa-simple)

closes #23