### PR TITLE
feat: allow configure falsy navigate fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/astro",
   "type": "module",
   "version": "0.1.4",
-  "packageManager": "pnpm@8.9.2",
+  "packageManager": "pnpm@8.10.3",
   "description": "Zero-config PWA for Astro",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,8 @@ function getViteConfiguration(
       injectRegister,
     }
 
-    if (!useWorkbox.navigateFallback)
+    // the user may want to disable offline support
+    if (!('navigateFallback' in useWorkbox))
       useWorkbox.navigateFallback = config.base ?? config.vite?.base ?? '/'
 
     if (directoryFormat)


### PR DESCRIPTION
When using generate strategy and providing navigateFallback with null or undefined, the module will change the value to the base