### PR TITLE
fix(injectManifest): astro with env files not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/astro",
   "type": "module",
   "version": "0.3.0",
-  "packageManager": "pnpm@8.15.3",
+  "packageManager": "pnpm@8.15.5",
   "description": "Zero-config PWA for Astro",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",
@@ -44,7 +44,7 @@
   "peerDependencies": {
     "@vite-pwa/assets-generator": "^0.2.4",
     "astro": "^1.6.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
-    "vite-plugin-pwa": ">=0.19.0 <1"
+    "vite-plugin-pwa": ">=0.19.6 <1"
   },
   "peerDependenciesMeta": {
     "@vite-pwa/assets-generator": {
@@ -52,7 +52,7 @@
     }
   },
   "dependencies": {
-    "vite-plugin-pwa": ">=0.19.0 <1"
+    "vite-plugin-pwa": ">=0.19.6 <1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.43.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.2.4
         version: 0.2.4
       vite-plugin-pwa:
-        specifier: '>=0.19.0 <1'
-        version: 0.19.0(@vite-pwa/assets-generator@0.2.4)(vite@5.0.5)(workbox-build@7.0.0)(workbox-window@7.0.0)
+        specifier: '>=0.19.6 <1'
+        version: 0.19.6(@vite-pwa/assets-generator@0.2.4)(vite@5.0.5)(workbox-build@7.0.0)(workbox-window@7.0.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.43.1
@@ -5070,7 +5070,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -5081,7 +5081,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
@@ -8681,8 +8681,8 @@ packages:
       vfile-message: 4.0.2
     dev: true
 
-  /vite-plugin-pwa@0.19.0(@vite-pwa/assets-generator@0.2.4)(vite@5.0.5)(workbox-build@7.0.0)(workbox-window@7.0.0):
-    resolution: {integrity: sha512-Unfb4Jk/ka4HELtpMLIPCmGcW4LFT+CL7Ri1/Of1544CVKXS2ftP91kUkNzkzeI1sGpOdVGuxprVLB9NjMoCAA==}
+  /vite-plugin-pwa@0.19.6(@vite-pwa/assets-generator@0.2.4)(vite@5.0.5)(workbox-build@7.0.0)(workbox-window@7.0.0):
+    resolution: {integrity: sha512-3hoxgrDGRzh1vidcZ/GSKXBDiZqbL8DRHXkJgkbJ2Xp3+/P4nau6118L5XlJJsm/wXPpwc/JpDj6Mf073s69+A==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@vite-pwa/assets-generator': ^0.2.4


### PR DESCRIPTION
This PR updates PWA plugin, the custom Vite build not including `envDir` and `envPrefix`: Astro using `PUBLIC_` prefix instead `VITE_` (Vite default).

The PWA plugin `0.19.6`  includes a custom function for integrations to allow update the Vite configuration for the custom sw build (`integration.configureCustomSWViteBuild`).

closes #42