### PR TITLE
chore: add `pkg.pr.new`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+### Description
+
+<!-- Please insert your description here and provide info about the "what" this PR is solving. -->
+
+<!----------------------------------------------------------------------
+Before creating the pull request, please make sure you do the following:
+
+- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
+- Read the contribution docs at https://github.com/vite-pwa/astro/blob/main/CONTRIBUTING.md
+- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
+- Update the corresponding documentation if needed.
+- Include relevant tests that fail without this PR but pass with it.
+
+Thank you for contributing to vite-pwa/astro!
+----------------------------------------------------------------------->
+
+### Linked Issues
+
+<!-- e.g. fixes #123 -->
+
+### Additional Context
+
+<!-- Is there anything you would like the reviewers to focus on? -->
+
+---
+
+> [!TIP]
+> The author of this PR can publish a _preview release_ by commenting `/publish` below.

--- a/.github/workflows/cr-comment.yml
+++ b/.github/workflows/cr-comment.yml
@@ -1,0 +1,18 @@
+name: Add continuous release label
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: ${{ github.event.issue.pull_request && (github.event.comment.user.id == github.event.issue.user.id || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') && startsWith(github.event.comment.body, '/publish') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: gh issue edit ${{ github.event.issue.number }} --add-label cr-tracked --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_PAT }}

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,0 +1,27 @@
+name: CR
+
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    if: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'cr-tracked') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4.0.0
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpx pkg-pr-new publish --compact --no-template --pnpm

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vite-pwa/astro",
   "type": "module",
   "version": "0.4.0",
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.7.1",
   "description": "Zero-config PWA for Astro",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This PR includes:
- bump `pnpm`  to 9.7.1
- add PR template
- add CR comment workflow via `/publish` (tip on the PR template)
- add CR workflow to use `/publish`  comment

/cc @Aslemammad