### PR TITLE
fix: use the client build folder when the adapter is present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,11 @@ function getViteConfiguration(
   if (assets[assets.length - 1] !== '/')
     assets += '/'
 
+  const adapter = config.adapter?.name
+
+  if (adapter)
+    options.outDir = fileURLToPath(config.build.client)
+
   if (options.pwaAssets) {
     options.pwaAssets.integration = {
       baseUrl: config.base ?? config.vite.base ?? '/',
@@ -206,6 +211,10 @@ function getViteConfiguration(
       registerType,
       injectRegister,
     }
+
+    // the user may want to disable offline support
+    if (adapter && !('globDirectory' in useWorkbox))
+      useWorkbox.globDirectory = fileURLToPath(config.build.client)
 
     // the user may want to disable offline support
     if (!('navigateFallback' in useWorkbox))
@@ -232,6 +241,10 @@ function getViteConfiguration(
   }
 
   options.injectManifest = options.injectManifest ?? {}
+  // the user may want to disable offline support
+  if (adapter && !('globDirectory' in options.injectManifest))
+    options.injectManifest.globDirectory = fileURLToPath(config.build.client)
+
   // Astro4/ Vite5 support: allow override dontCacheBustURLsMatching
   if (!('dontCacheBustURLsMatching' in options.injectManifest))
     options.injectManifest.dontCacheBustURLsMatching = new RegExp(assets)


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide info about the "what" this PR is solving. -->

resolves #66

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/vite-pwa/astro/blob/main/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to vite-pwa/astro!
----------------------------------------------------------------------->

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->

---

> [!TIP]
> The author of this PR can publish a _preview release_ by commenting `/publish` below.
